### PR TITLE
photon-browser 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# `$ photon-browser` [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/photon-browser.svg)](https://www.npmjs.com/package/photon-browser) [![Downloads](https://img.shields.io/npm/dt/photon-browser.svg)](https://www.npmjs.com/package/photon-browser) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# `$ photon-browser`
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/photon-browser.svg)](https://www.npmjs.com/package/photon-browser) [![Downloads](https://img.shields.io/npm/dt/photon-browser.svg)](https://www.npmjs.com/package/photon-browser) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > A tiny web browser based on Photon and Electron.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photon-browser",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A tiny web browser based on Photon and Electron.",
   "main": "lib/index.js",
   "bin": {
@@ -42,6 +42,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
